### PR TITLE
Fix/ Image Profile 5MB limit

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -17,7 +17,8 @@ const httpServer = createServer(server);
 // Inicializar Socket.IO
 const socketService = new SocketService(httpServer);
 
-server.use(express.json());
+server.use(express.json({ limit: '5mb' }));
+server.use(express.urlencoded({ limit: '5mb', extended: true }));
 const allowedOrigins = [
   'http://localhost:3000',
   'https://whomessage.vercel.app'

--- a/frontend/src/app/home/Profile.tsx
+++ b/frontend/src/app/home/Profile.tsx
@@ -94,9 +94,14 @@ function ProfileComponent({ user, userGames, userInterests, onProfileUpdate }: P
     );
   };
 
+  const MAX_IMAGE_SIZE = 2 * 1024 * 1024; // 2MB
   const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
+      if (file.size > MAX_IMAGE_SIZE) {
+        toast.error('Imagem muito grande! Escolha uma imagem menor que 2MB.');
+        return;
+      }
       const reader = new FileReader();
       reader.onload = (e) => {
         setFormData(prev => ({ ...prev, pfp: e.target?.result as string }));
@@ -142,9 +147,18 @@ function ProfileComponent({ user, userGames, userInterests, onProfileUpdate }: P
       // Limpar o campo de novo nickname
       setFormData(prev => ({ ...prev, newNickname: '' }));
       toast.success('Perfil atualizado com sucesso!');
-    } catch (error) {
+    } catch (error: any) {
       console.error('Erro ao salvar perfil:', error);
-      toast.error('Erro ao salvar perfil');
+      // Tenta identificar erro de payload grande
+      if (
+        error?.response?.data?.error?.includes('PayloadTooLargeError') ||
+        error?.message?.includes('PayloadTooLargeError') ||
+        error?.response?.status === 413
+      ) {
+        toast.error('Imagem muito grande! Escolha uma imagem menor.');
+      } else {
+        toast.error('Erro ao salvar perfil');
+      }
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
This pull request introduces improvements to both backend and frontend code to enhance data handling and user experience. The main changes include increasing the payload size limits for incoming requests on the backend and adding client-side validation for avatar image uploads in the frontend.

**Backend enhancements:**

* Increased the payload size limit for JSON and URL-encoded requests to 5MB in `server.ts` to support larger incoming data, such as images.

**Frontend improvements:**

* Added a 2MB file size validation for avatar uploads in `Profile.tsx`, displaying an error toast if the selected image exceeds this limit.