### PR TITLE
fix: swipe for mobile unlock, messages ui-ux improvment

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -17,7 +17,14 @@
   --input-focus: #374151;
 }
 
+html {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
+  height: 100%;
+  overflow: hidden;
   color: var(--foreground);
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
@@ -25,8 +32,6 @@ body {
     radial-gradient(circle at 20% 50%, rgba(99, 102, 241, 0.05) 0%, transparent 50%),
     radial-gradient(circle at 80% 20%, rgba(162, 28, 175, 0.05) 0%, transparent 50%),
     radial-gradient(circle at 40% 80%, rgba(99, 102, 241, 0.03) 0%, transparent 50%);
-  min-height: 100vh;
-  overflow-x: hidden; /* Previne barra de rolagem horizontal */
 }
 
 html {

--- a/frontend/src/app/home/MenuSwipe.tsx
+++ b/frontend/src/app/home/MenuSwipe.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { useRecommendations } from "../../hooks/useRecommendations";
 import { reportsAPI } from "../../lib/api";
 import { toast } from "react-toastify";
@@ -190,27 +190,25 @@ export default function MenuSwipe() {
     document.addEventListener('mouseup', onUp);
   };
 
-  // handleSwipeRef — permite que o listener nativo (useEffect abaixo) sempre
-  // acesse a versão mais recente de handleSwipe sem fechar sobre estado stale.
+  // handleSwipeRef — sempre aponta para a versão mais recente de handleSwipe.
   const handleSwipeRef = useRef<(dir: 'left' | 'right') => void>(() => {});
   handleSwipeRef.current = handleSwipe;
 
-  // Touch events com listener NATIVO não-passivo — essencial para poder chamar
-  // e.preventDefault() e evitar concorrência com o scroll nativo do browser.
-  // onTouchMove do React é passivo por padrão e não pode bloquear o scroll.
-  useEffect(() => {
-    const el = cardRef.current;
-    if (!el) return;
+  // snapBackRef — mesma razão: evita stale closure nos handlers de touch.
+  const snapBackRef = useRef(snapBack);
+  snapBackRef.current = snapBack;
 
-    const onStart = (e: TouchEvent) => {
+  // Handlers com identidade estável (objeto criado uma única vez via useRef).
+  // Todos os valores internos lidos em runtime são refs → sem stale closure.
+  const touchHandlers = useRef({
+    onStart(e: TouchEvent) {
       if (isAnimatingRef.current) return;
       gestureRef.current = 'none';
       const t = e.touches[0];
       startPos.current = { x: t.clientX, y: t.clientY };
       lastTouchYRef.current = t.clientY;
-    };
-
-    const onMove = (e: TouchEvent) => {
+    },
+    onMove(e: TouchEvent) {
       if (isAnimatingRef.current) return;
       const t = e.touches[0];
       const dx = t.clientX - startPos.current.x;
@@ -222,44 +220,48 @@ export default function MenuSwipe() {
         if (Math.abs(dx) > 8 || Math.abs(dy) > 8) {
           gestureRef.current = Math.abs(dx) >= Math.abs(dy) ? 'horizontal' : 'vertical';
         }
-        // Bloqueia qualquer default durante a fase de detecção
         e.preventDefault();
         return;
       }
 
       if (gestureRef.current === 'horizontal') {
-        // Impede scroll nativo ao arrastar horizontalmente
         e.preventDefault();
         dragXRef.current = dx;
         applyTransform(dx);
       } else if (scrollContainerRef.current) {
-        // Scroll vertical manual — preventDefault evita conflito com scroll nativo
         e.preventDefault();
         scrollContainerRef.current.scrollTop += moveDY;
       }
-    };
-
-    const onEnd = () => {
+    },
+    onEnd() {
       if (gestureRef.current === 'horizontal') {
         if (Math.abs(dragXRef.current) > 80) {
           handleSwipeRef.current(dragXRef.current > 0 ? 'right' : 'left');
         } else {
-          snapBack();
+          snapBackRef.current();
         }
       }
       gestureRef.current = 'none';
-    };
+    },
+  });
 
-    el.addEventListener('touchstart', onStart, { passive: false });
-    el.addEventListener('touchmove', onMove, { passive: false });
-    el.addEventListener('touchend', onEnd, { passive: true });
-
-    return () => {
-      el.removeEventListener('touchstart', onStart);
-      el.removeEventListener('touchmove', onMove);
-      el.removeEventListener('touchend', onEnd);
-    };
-  }, []); // todos os valores usados são refs — sem risco de stale closure
+  // Callback ref: chamado pelo React quando o card entra/sai do DOM.
+  // Elimina a necessidade de useEffect + deps array — sem problemas de tamanho.
+  const setCardRef = useCallback((el: HTMLDivElement | null) => {
+    const { onStart, onMove, onEnd } = touchHandlers.current;
+    const prev = (cardRef as React.MutableRefObject<HTMLDivElement | null>).current;
+    if (prev) {
+      prev.removeEventListener('touchstart', onStart);
+      prev.removeEventListener('touchmove', onMove);
+      prev.removeEventListener('touchend', onEnd);
+    }
+    (cardRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+    if (el) {
+      el.addEventListener('touchstart', onStart, { passive: false });
+      el.addEventListener('touchmove', onMove, { passive: false });
+      el.addEventListener('touchend', onEnd, { passive: true });
+    }
+  }, []);
 
   // Função para abrir modal de report
   const handleReportClick = () => {
@@ -335,7 +337,7 @@ export default function MenuSwipe() {
     <div className="flex flex-col items-center px-4 py-2" style={{ height: 'calc(100dvh - 128px)', overflow: 'hidden' }}>
       <div className="relative w-full max-w-sm flex flex-col" style={{ height: '100%' }}>
         <div
-          ref={cardRef}
+          ref={setCardRef}
           className="relative bg-card rounded-2xl shadow-2xl border border-card-border flex flex-col flex-1 min-h-0 cursor-grab active:cursor-grabbing"
           style={{ userSelect: 'none', WebkitUserSelect: 'none', touchAction: 'none', willChange: 'transform' } as React.CSSProperties}
           onMouseDown={handleMouseDown}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,10 +1,19 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 
 import ProtectedLayout from "./protected-layout";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  // Faz o teclado virtual redimensionar o layout viewport em vez de sobrepor.
+  // Isso garante que h-dvh encolhe corretamente quando o teclado abre,
+  // eliminando o scroll externo e o gap que aparece ao fechar o teclado.
+  interactiveWidget: 'resizes-content',
+};
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",


### PR DESCRIPTION
This pull request improves the touch/swipe handling in the `MenuSwipe` component and updates global layout and viewport behavior to better support mobile devices, especially when dealing with virtual keyboards. The most significant changes are a refactor of touch event handling to prevent stale closures and a viewport configuration that ensures the layout resizes correctly when the on-screen keyboard appears.

Touch/swipe event handling improvements:
* Refactored touch event listeners in `MenuSwipe.tsx` to use stable handler identities via `useRef`, preventing stale closures and ensuring up-to-date logic during user interactions. Touch handlers are now attached/detached using a callback ref (`setCardRef`) instead of `useEffect`, simplifying the code and improving reliability. (`frontend/src/app/home/MenuSwipe.tsx` [[1]](diffhunk://#diff-c5acf09c09f8d76019fea8e0043343a705f4811cd3c7d80eed46094def639fc6L193-R211) [[2]](diffhunk://#diff-c5acf09c09f8d76019fea8e0043343a705f4811cd3c7d80eed46094def639fc6L225-R264) [[3]](diffhunk://#diff-c5acf09c09f8d76019fea8e0043343a705f4811cd3c7d80eed46094def639fc6L338-R340)
* Updated imports to include `useCallback` for the new ref-based handler approach. (`frontend/src/app/home/MenuSwipe.tsx` [frontend/src/app/home/MenuSwipe.tsxL2-R2](diffhunk://#diff-c5acf09c09f8d76019fea8e0043343a705f4811cd3c7d80eed46094def639fc6L2-R2))

Mobile layout and viewport enhancements:
* Added a `viewport` export in `layout.tsx` to set `interactiveWidget: 'resizes-content'`, ensuring the viewport and layout resize when the virtual keyboard opens, preventing unwanted scroll and layout gaps on mobile devices. (`frontend/src/app/layout.tsx` [frontend/src/app/layout.tsxL1-R17](diffhunk://#diff-f3bfc5eb8ab49540cf25bb4422d423fac9a4e15f744eb2e2d3b2e1a1b03e441fL1-R17))
* Updated `globals.css` to set `height: 100%` and `overflow: hidden` on both `html` and `body`, removing previous min-height and overflow-x rules, to further prevent unwanted scrollbars and layout issues. (`frontend/src/app/globals.css` [frontend/src/app/globals.cssR20-L29](diffhunk://#diff-87958537a79d51d35702beb783d9e8a8aea8d2b455ce6f65fb5e3cce3061318fR20-L29))